### PR TITLE
Fixed the cookie persistence issue. (Issue #10)

### DIFF
--- a/AppHarbor.Web.Security/AuthenticationCookie.cs
+++ b/AppHarbor.Web.Security/AuthenticationCookie.cs
@@ -110,7 +110,7 @@ namespace AppHarbor.Web.Security
 
 		public bool IsExpired(TimeSpan validity)
 		{
-			return !Persistent && _issueDate.Add(validity) <= DateTime.UtcNow;
+			return _issueDate.Add(validity) <= DateTime.UtcNow;
 		}
 
 		public DateTime IssueDate

--- a/AppHarbor.Web.Security/CookieAuthenticationModule.cs
+++ b/AppHarbor.Web.Security/CookieAuthenticationModule.cs
@@ -69,7 +69,7 @@ namespace AppHarbor.Web.Security
 				HttpOnly = true,
 				Secure = _configuration.RequireSSL,
 			};
-			if (!authenticationCookie.Persistent)
+			if (authenticationCookie.Persistent)
 			{
 				newCookie.Expires = authenticationCookie.IssueDate + _configuration.Timeout;
 			}

--- a/AppHarbor.Web.Security/CookieAuthenticator.cs
+++ b/AppHarbor.Web.Security/CookieAuthenticator.cs
@@ -29,7 +29,7 @@ namespace AppHarbor.Web.Security
 					HttpOnly = true,
 					Secure = _configuration.RequireSSL,
 				};
-				if (!persistent)
+				if (persistent)
 				{
 					httpCookie.Expires = cookie.IssueDate + _configuration.Timeout;
 				}


### PR DESCRIPTION
The cookie expiration date should be set only if the cookie is
persistent, not the other way around.  The previous code did
exactly the opposite.

This is a fix for issue #10 
