### PR TITLE
Removed provably false and useless condition in HMAC validation

### DIFF
--- a/AppHarbor.Web.Security/KeyedHashValidation.cs
+++ b/AppHarbor.Web.Security/KeyedHashValidation.cs
@@ -64,10 +64,6 @@ namespace AppHarbor.Web.Security
 			}
 			for (int i = 0; i < validSignature.Length; i++)
 			{
-				if (i + dataLength >= signedMessage.Length)
-				{
-					isValid = false;
-				}
 				if (signedMessage[i + dataLength] != validSignature[i])
 				{
 					isValid = false;


### PR DESCRIPTION
There is an if statement right outside the loop that ensures the condition the removed "if" statement checks is never true. Even if it weren't there, this "if" would have been incorrectly written as an ArgumentOutOfRange exception will get thrown anyway while evaluating the following "if"'s condition. 
