### PR TITLE
Adding a cookie validation interface to block disabled accounts

### DIFF
--- a/AppHarbor.Web.Security/AppHarbor.Web.Security.csproj
+++ b/AppHarbor.Web.Security/AppHarbor.Web.Security.csproj
@@ -46,6 +46,7 @@
     <Compile Include="Encryption.cs" />
     <Compile Include="IAuthenticator.cs" />
     <Compile Include="ICookieAuthenticationConfiguration.cs" />
+    <Compile Include="ICookieValidator.cs" />
     <Compile Include="KeyedHashValidation.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StringExtensions.cs" />

--- a/AppHarbor.Web.Security/ICookieValidator.cs
+++ b/AppHarbor.Web.Security/ICookieValidator.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace AppHarbor.Web.Security
+{
+    public interface ICookieValidator
+    {
+        bool IsCookieValid(AuthenticationCookie cookie);
+    }
+}


### PR DESCRIPTION
One thing I thought of was that if you disable the user account in the user repository, the user will still be authentified by the http module. And if the user has a persistent cookie, he can keep on having it refreshed and never expired, and keep on being logged even with a disabled account.

Same thing if the user changes his password. Any cookie on other browsers will still be valid, even if the password that was used to validate them has changed.
. 
So I added a ICookieValidation interface, that allows the user repository to verify the cookie, i.e check the user account is not disabled , and if cookie date is > last password change date.

Injection of depedencies on an http module (loaded before the application_start) can be tricky, but http://haacked.com/archive/2011/06/03/dependency-injection-with-asp-net-httpmodules.aspx/ worked.
